### PR TITLE
WIP Openplanner.1.15 stamped lanes

### DIFF
--- a/op_local_planner/include/op_behavior_selector_core.h
+++ b/op_local_planner/include/op_behavior_selector_core.h
@@ -37,6 +37,7 @@
 #include <geometry_msgs/PoseArray.h>
 #include <nav_msgs/Odometry.h>
 #include <autoware_msgs/LaneArray.h>
+#include <autoware_msgs/LaneArrayStamped.h>
 #include <std_msgs/Int32MultiArray.h>
 #include <std_msgs/Int32.h>
 #include <std_msgs/Float32.h>
@@ -164,7 +165,7 @@ protected: //Planning Related variables
 	//Path Planning Section
 	//----------------------------
 	void callbackGetGlobalPlannerPath(const autoware_msgs::LaneArrayConstPtr& msg);
-	void callbackGetLocalPlannerPath(const autoware_msgs::LaneArrayConstPtr& msg);
+	void callbackGetLocalPlannerPath(const autoware_msgs::LaneArrayStampedConstPtr& msg);
 	void callbackGetLocalTrajectoryCost(const autoware_msgs::LaneConstPtr& msg);
 	void CollectRollOutsByGlobalPath(std::vector< std::vector<PlannerHNS::WayPoint> >& local_rollouts);
 	bool CompareTrajectoriesWithIds(std::vector<std::vector<PlannerHNS::WayPoint> >& paths, std::vector<int>& local_ids);

--- a/op_local_planner/include/op_trajectory_evaluator_core.h
+++ b/op_local_planner/include/op_trajectory_evaluator_core.h
@@ -25,6 +25,7 @@
 #include <geometry_msgs/PoseArray.h>
 #include <nav_msgs/Odometry.h>
 #include <autoware_msgs/LaneArray.h>
+#include <autoware_msgs/LaneArrayStamped.h>
 #include <autoware_can_msgs/CANInfo.h>
 #include <autoware_msgs/DetectedObjectArray.h>
 #include <autoware_msgs/VehicleStatus.h>
@@ -59,6 +60,7 @@ protected:
 	std::vector<std::vector<PlannerHNS::WayPoint> > m_GlobalPaths;
 	std::vector<std::vector<PlannerHNS::WayPoint> > m_GlobalPathsToUse;
 	std::vector<std::vector<PlannerHNS::WayPoint> > m_GlobalPathSections;
+        ros::Time path_stamp;
 	std::vector<int> m_prev_index;
 	std::vector<PlannerHNS::WayPoint> t_centerTrajectorySmoothed;
 	bool bEnableSmoothGlobalPathForCARLA;
@@ -115,7 +117,7 @@ protected:
 	void callbackGetRobotOdom(const nav_msgs::OdometryConstPtr& msg);
 	void callbackGetVehicleStatus(const autoware_msgs::VehicleStatusConstPtr & msg);
 	void callbackGetGlobalPlannerPath(const autoware_msgs::LaneArrayConstPtr& msg);
-	void callbackGetLocalPlannerPath(const autoware_msgs::LaneArrayConstPtr& msg);
+	void callbackGetLocalPlannerPath(const autoware_msgs::LaneArrayStampedConstPtr& msg);
 	void callbackGetPredictedObjects(const autoware_msgs::DetectedObjectArrayConstPtr& msg);
 	void callbackGetTrajectoryInforFromBehaviorSelector(const std_msgs::Int32MultiArrayConstPtr& msg);
 

--- a/op_local_planner/include/op_trajectory_generator_core.h
+++ b/op_local_planner/include/op_trajectory_generator_core.h
@@ -25,6 +25,7 @@
 #include <geometry_msgs/PoseArray.h>
 #include <nav_msgs/Odometry.h>
 #include <autoware_msgs/LaneArray.h>
+#include <autoware_msgs/LaneArrayStamped.h>
 #include <autoware_msgs/VehicleStatus.h>
 #include <autoware_can_msgs/CANInfo.h>
 

--- a/op_local_planner/nodes/op_trajectory_generator/op_trajectory_generator_core.cpp
+++ b/op_local_planner/nodes/op_trajectory_generator/op_trajectory_generator_core.cpp
@@ -45,7 +45,7 @@ TrajectoryGen::TrajectoryGen()
 	m_OriginPos.position.z  = transform.getOrigin().z();
 
 	pub_PathsRviz = nh.advertise<visualization_msgs::MarkerArray>("global_waypoints_rviz", 1, true);
-	pub_LocalTrajectories = nh.advertise<autoware_msgs::LaneArray>("local_trajectories", 1);
+	pub_LocalTrajectories = nh.advertise<autoware_msgs::LaneArrayStamped>("local_trajectories", 1);
 	pub_LocalTrajectoriesRviz = nh.advertise<visualization_msgs::MarkerArray>("local_trajectories_gen_rviz", 1);
 
 	sub_initialpose = nh.subscribe("/initialpose", 1, &TrajectoryGen::callbackGetInitPose, this);
@@ -442,7 +442,7 @@ void TrajectoryGen::MainLoop()
 				m_SmoothRollOuts = m_RollOuts;
 			}
 
-			autoware_msgs::LaneArray local_lanes;
+			autoware_msgs::LaneArrayStamped local_lanes;
 			for(unsigned int i=0; i < m_SmoothRollOuts.size(); i++)
 			{
 				for(unsigned int j=0; j < m_SmoothRollOuts.at(i).size(); j++)
@@ -458,6 +458,7 @@ void TrajectoryGen::MainLoop()
 					local_lanes.lanes.push_back(lane);
 				}
 			}
+                        local_lanes.header.stamp = ros::Time::now();
 			pub_LocalTrajectories.publish(local_lanes);
 		}
 		else


### PR DESCRIPTION
**This PR is part of the effort of merging back the changes made by the University of Tartu Self driving Lab.**

Creating a new message type : LaneArrayStamped with the following definition :

```
Header header
LaneArray lanearray
```

It allows stamp the message when it's created in the `op_trajectory_generator` and keep the stamp when going through the `op_trajectory_evaluator`. It allows to measure the delay on the topic `/local_weighted_trajectories` that is caused by the trajectory evaluation. (Maybe the most time consuming part)

![image](https://user-images.githubusercontent.com/22786578/120668210-e9b4a280-c496-11eb-81c1-2bd4ecc5ea97.png)

This PR does not contain the message definition so it is not functional as is. 
What's your opinion on this function ? If you think it's useful I can complete this PR.