### PR TITLE
Added steering angle and linear velocity to op_controller_cmd publisher

### DIFF
--- a/op_waypoint_follower/nodes/op_waypoint_follower_core.cpp
+++ b/op_waypoint_follower/nodes/op_waypoint_follower_core.cpp
@@ -399,9 +399,26 @@ void WaypointFollower::PathFollowingStep(double dt)
 	if(m_iSimulationMode == 2)
 	{
 		autoware_msgs::VehicleCmd cmd;
-		cmd.steer_cmd.steer = -m_curr_target_status.steer_torque;
-		cmd.accel_cmd.accel = m_curr_target_status.accel_stroke;
-		cmd.brake_cmd.brake = m_curr_target_status.brake_stroke;
+
+		// select lateral control mode
+		if (m_ControllerHyperParams.bEnableSteeringMode){
+			cmd.steer_cmd.steer = m_curr_target_status.steer*(180/3.141);
+		} 
+		else
+		{
+			cmd.steer_cmd.steer = -m_curr_target_status.steer_torque;
+		}
+
+		// select longitudinal control mode
+		if (m_ControllerHyperParams.bEnableVelocityMode){
+			cmd.ctrl_cmd.linear_velocity = m_curr_target_status.speed;
+		} 
+		else
+		{
+			cmd.accel_cmd.accel = m_curr_target_status.accel_stroke;
+			cmd.brake_cmd.brake = m_curr_target_status.brake_stroke;
+		}
+		
 		pub_VehicleCommandOP.publish(cmd);
 	}
 }


### PR DESCRIPTION
The topic "op_controller_cmd" was missing the steering angle and velocity for the direct control feature. Previously only torque steering and pedal stroke was published.