### PR TITLE
Add new a hyper parameter to enable or disable the avoidance in the last section 

### DIFF
--- a/op_local_planner/launch/op_common_params.launch
+++ b/op_local_planner/launch/op_common_params.launch
@@ -29,7 +29,7 @@
 	<arg name="enableTrafficLightBehavior" 	default="false" />
 	<arg name="enableStopSignBehavior" 		default="false" />	
 	<arg name="enableLaneChange" 			default="false" />	
-	
+	<arg name="enableFinalLocalPathUpdate" 	default="true" />	
 	<!-- Vehicle Info, shared with controller and simulation -->
 	<arg name="height" 						default="1.47"  />
 	<arg name="front_length"				default="1.0"  />
@@ -92,6 +92,7 @@
 		<param name="enableTrafficLightBehavior" value="$(arg enableTrafficLightBehavior)" />
 		<param name="enableStopSignBehavior" 	value="$(arg enableStopSignBehavior)" />	
 		<param name="enableLaneChange" 			value="$(arg enableLaneChange)" />
+		<param name="enableFinalLocalPathUpdate" value="$(arg enableFinalLocalPathUpdate)" />
 		
 		<param name="height" 					value="$(arg height)"  />		
 		<param name="front_length" 				value="$(arg front_length)"  />

--- a/op_local_planner/nodes/op_behavior_selector/op_behavior_selector_core.cpp
+++ b/op_local_planner/nodes/op_behavior_selector/op_behavior_selector_core.cpp
@@ -135,7 +135,7 @@ void BehaviorGen::UpdatePlanningParams(ros::NodeHandle& _nh)
 
 	_nh.getParam("/op_common_params/horizontalSafetyDistance", m_PlanningParams.horizontalSafetyDistancel);
 	_nh.getParam("/op_common_params/verticalSafetyDistance", m_PlanningParams.verticalSafetyDistance);
-
+  	_nh.getParam("/op_common_params/enableFinalLocalPathUpdate", m_PlanningParams.enableFinalLocalPathUpdate);
 	_nh.getParam("/op_common_params/enableLaneChange", m_PlanningParams.enableLaneChange);
 
 	_nh.getParam("/op_common_params/front_length", m_CarInfo.front_length);


### PR DESCRIPTION
Hello, the maintainers of OpenPlanner.

As discussed in https://github.com/hatem-darweesh/autoware.ai.openplanner/issues/9, replan is not triggered if the current rollouts reach the goal. Thus some collision will happen while there are obstacles between ego and goal. In some scenarios(such as bus stop), as you mentioned, this is a reasonable design choice. We enable and disable avoidance manually in the last section based on the hyperparameter, as suggested by your opinion. This approach provides convenience for users to adapt to various driving scenarios.  Regarding the use of this hyper-parameter, we have already made the corresponding submission https://github.com/hatem-darweesh/common/pull/18. 
We are eagerly awaiting your feedback and response.