### PR TITLE
Block rollouts that cut through of drivable areas

### DIFF
--- a/op_local_planner/include/op_trajectory_evaluator_core.h
+++ b/op_local_planner/include/op_trajectory_evaluator_core.h
@@ -32,6 +32,7 @@
 #include "op_planner/TrajectoryEvaluator.h"
 #include "op_ros_helpers/ROSVelocityHandler.h"
 #include "op_ros_helpers/op_ParamsHandler.h"
+#include "op_ros_helpers/ROSMapHandler.h"
 
 namespace TrajectoryEvaluatorNS
 {
@@ -75,6 +76,7 @@ protected:
   	PlannerHNS::PlanningParams m_PlanningParams;
   	PlannerHNS::PlanningParams m_ModPlanningParams;
   	PlannerHNS::CAR_BASIC_INFO m_CarInfo;
+	PlannerHNS::MapHandler m_MapHandler;
 
   	PlannerHNS::BehaviorState m_CurrentBehavior;
   	double m_AdditionalFollowDistance;

--- a/op_local_planner/launch/op_common_params.launch
+++ b/op_local_planner/launch/op_common_params.launch
@@ -29,6 +29,7 @@
 	<arg name="enableTrafficLightBehavior" 	default="false" />
 	<arg name="enableStopSignBehavior" 		default="false" />	
 	<arg name="enableLaneChange" 			default="false" />	
+	<arg name="enableBlockingRolloutsOutOfMap"	default="false" />	
 	
 	<!-- Vehicle Info, shared with controller and simulation -->
 	<arg name="height" 						default="1.47"  />
@@ -92,6 +93,7 @@
 		<param name="enableTrafficLightBehavior" value="$(arg enableTrafficLightBehavior)" />
 		<param name="enableStopSignBehavior" 	value="$(arg enableStopSignBehavior)" />	
 		<param name="enableLaneChange" 			value="$(arg enableLaneChange)" />
+		<param name="enableBlockingRolloutsOutOfMap" value="$(arg enableBlockingRolloutsOutOfMap)" />
 		
 		<param name="height" 					value="$(arg height)"  />		
 		<param name="front_length" 				value="$(arg front_length)"  />


### PR DESCRIPTION
Hello, maintainers of OpenPlanner. 

Related to https://github.com/hatem-darweesh/common/pull/19. These two PR both aim to solve the same problem of blocking undrivable rollouts. However, to judge if a waypoint is inside drivable areas, the op_trajectory_evaluator should be able to access the map, which is supported by this PR.

And it also solves a minor problem of the mismatch of rollouts number, as described here: https://answers.ros.org/question/397945/openplanner-25-failed-to-achieve-lane-change-with-errors-in-op_trajectory_evaluator/